### PR TITLE
Add City ID option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ step is set the params for the request (request the api-key at http://openweathe
 	weather.setCity('Fairplay');
  	// or set the coordinates (latitude,longitude)
 	weather.setCoordinate(50.0467656, 20.0048731);
-	// or set city by ID (recommended by openweathermap)
-	weather.setCityId('4367872');
+	// or set city by ID (recommended by OpenWeatherMap)
+	weather.setCityId(4367872);
 
 	// 'metric'  'internal'  'imperial'
  	weather.setUnits('metric');

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ step is set the params for the request (request the api-key at http://openweathe
 	weather.setCity('Fairplay');
  	// or set the coordinates (latitude,longitude)
 	weather.setCoordinate(50.0467656, 20.0048731);
+	// or set city by ID (recommended by openweathermap)
+	weather.setCityId('4367872');
 
 	// 'metric'  'internal'  'imperial'
  	weather.setUnits('metric');

--- a/index.js
+++ b/index.js
@@ -32,6 +32,10 @@
     config.longitude = longitude;
   };
 
+  weather.setCityId = function(cityid){
+    config.cityId = cityid;
+  };
+
   weather.setUnits = function(units){
     config.units = units.toLowerCase();
   };
@@ -54,6 +58,10 @@
       "latitude": config.latitude,
       "longitude": config.longitude
     };
+  };
+
+  weather.getCityId = function(){
+    return config.cityId;
   };
 
   weather.getUnits = function(){
@@ -150,8 +158,10 @@
 
   function getCoordinate(){
     var coordinateAvailable = config.latitude && config.longitude;
+    var cityIdAvailable = config.cityId;
     var coordinateQuery = 'q='+config.city;
-    if (coordinateAvailable) coordinateQuery = 'lat='+config.latitude+'&lon='+config.longitude;
+    if (cityIdAvailable) coordinateQuery = 'id='+config.cityId;
+    else if (coordinateAvailable) coordinateQuery = 'lat='+config.latitude+'&lon='+config.longitude;
     return coordinateQuery;
   };
 

--- a/test/weather.js
+++ b/test/weather.js
@@ -36,6 +36,13 @@ describe('OpenWeatherMap ', function(){
 			expect(coordinates.latitude).be.equal(50.0467656);
 			expect(coordinates.longitude).be.equal(20.0048731);
 		});
+
+		it('Should set the City ID to 4367872', function(){
+			weather.setCityId(4367872);
+			var cityid = weather.getCityId();
+			expect(cityid).be.not.empty;
+			expect(cityid).be.equal(4367872);
+		});
 	});
 
 	describe('Retrive data : ', function(){


### PR DESCRIPTION
OpenWeatherMap suggests that using the City ID is the preferred method for the API to 'avoid ambiguous result for your city'.
I have added this option (also maintaining existing fall-back to coordinates or City name).