### PR TITLE
Add `withCredentials: false` to fix issue #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@
   var http = require('http');
   var options = {
     host : 'api.openweathermap.org',
-    path: '/data/2.5/weather?q=fairplay'
+    path: '/data/2.5/weather?q=fairplay',
+    withCredentials: false
   };
 
   var weather = exports;

--- a/index.js
+++ b/index.js
@@ -186,7 +186,6 @@
     options.path = url;
     http.get(options, function(res){
       var chunks = '';
-      res.setEncoding('utf-8');
       res.on('data', function(chunk) {
           chunks += chunk;
       });


### PR DESCRIPTION
Add `withCredentials: false` to fix issue https://github.com/CICCIOSGAMINO/openweather-apis/issues/15

Remove `res.setEncoding('utf8')` to fix `Uncaught TypeError: res.setEncoding is not a function`