### PR TITLE
Removed double encoding of city name

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@
   };
 
   weather.setCity = function(city){
-    config.city = encodeURIComponent(city.toLowerCase());
+    config.city = city.toLowerCase();
   };
 
   weather.setCoordinate = function(latitude, longitude){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openweather-apis",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Simple APIs to use with OpenWeatherMap.org free servicies, request a APPID on http://openweathermap.org/appid and start!",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes #28 

Little PR to fix the api call with a city name including country code e.g. "Berlin, DE".

The encoding happens twice:
- in line [32](https://github.com/CICCIOSGAMINO/openweather-apis/blob/master/index.js#L32)
- in line [210](https://github.com/CICCIOSGAMINO/openweather-apis/blob/master/index.js#L210)

I removed the encoding in line 32.
I updated the package json to version 4.2.1

Watch out, the issue also exists in branch v5.0.0-pre.